### PR TITLE
CSS: Reduce margin for color header

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -63,7 +63,7 @@ body {
 
 .color-header {
   color: rgb(44, 39, 39);
-  margin: 20px;
+  margin: 18px;
 }
 
 .canvas-container {


### PR DESCRIPTION
![Screenshot 2024-10-08 224448](https://github.com/user-attachments/assets/1f0ef7b7-39d4-442d-b559-ef4134fb2bfd)

Reducing the margin will not put the colons on next line